### PR TITLE
Add a `.py.typed` file

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -21,6 +21,7 @@ classifiers =
     Operating System :: POSIX :: Linux
     Development Status :: 5 - Production/Stable
     Topic :: Desktop Environment :: File Managers
+    Typing :: Typed
 [options]
 package_dir =
     = src


### PR DESCRIPTION
This lets type checkers know that the package contains inline types, meaning that they won't generate annoying errors about using an untyped library if a user imports a function from the package (see [PEP 561](https://peps.python.org/pep-0561/) for more details).

Closes #5