### PR TITLE
dl-branch-1

### DIFF
--- a/.idea/inspectionProfiles/profiles_settings.xml
+++ b/.idea/inspectionProfiles/profiles_settings.xml
@@ -1,5 +1,6 @@
 <component name="InspectionProjectProfileManager">
   <settings>
+    <option name="PROJECT_PROFILE" value="Default" />
     <option name="USE_PROJECT_PROFILE" value="false" />
     <version value="1.0" />
   </settings>

--- a/.idea/misc.xml
+++ b/.idea/misc.xml
@@ -3,5 +3,12 @@
   <component name="Black">
     <option name="sdkName" value="Python 3.12 (showinfilemanager)" />
   </component>
-  <component name="ProjectRootManager" version="2" project-jdk-name="Python 3.12 (showinfilemanager)" project-jdk-type="Python SDK" />
+  <component name="ProjectRootManager" version="2" project-jdk-name="Hatch (show-in-file-manager) [3.14]" project-jdk-type="Python SDK" />
+  <component name="PythonCompatibilityInspectionAdvertiser">
+    <option name="version" value="3" />
+  </component>
+  <component name="RuffConfiguration">
+    <option name="enabled" value="true" />
+    <option name="executableDiscoveryMode" value="PATH" />
+  </component>
 </project>

--- a/.idea/scopes/Damon_Lynch_exclusive_MIT__code.xml
+++ b/.idea/scopes/Damon_Lynch_exclusive_MIT__code.xml
@@ -1,3 +1,3 @@
 <component name="DependencyValidationManager">
-  <scope name="Damon Lynch exclusive MIT  code" pattern="file:src//*.py&amp;&amp;!file:src/showinfm/system/urivalidate.py" />
+  <scope name="Damon Lynch exclusive MIT  code" pattern="file:src//*.py&amp;&amp;!file:src/showinfm/system/urivalidate.py&amp;&amp;!file:src/showinfm/system/tools.py" />
 </component>

--- a/.idea/showinfilemanager.iml
+++ b/.idea/showinfilemanager.iml
@@ -2,12 +2,13 @@
 <module type="PYTHON_MODULE" version="4">
   <component name="NewModuleRootManager">
     <content url="file://$MODULE_DIR$">
+      <sourceFolder url="file://$MODULE_DIR$/src" isTestSource="false" />
       <sourceFolder url="file://$MODULE_DIR$/src/showinfm" isTestSource="false" />
       <excludeFolder url="file://$MODULE_DIR$/venv" />
       <excludeFolder url="file://$MODULE_DIR$/src/show_in_file_manager.egg-info" />
       <excludeFolder url="file://$MODULE_DIR$/venv38" />
     </content>
-    <orderEntry type="jdk" jdkName="Python 3.12 (showinfilemanager)" jdkType="Python SDK" />
+    <orderEntry type="jdk" jdkName="Hatch (show-in-file-manager) [3.14]" jdkType="Python SDK" />
     <orderEntry type="sourceFolder" forTests="false" />
   </component>
 </module>

--- a/src/cli.py
+++ b/src/cli.py
@@ -1,9 +1,7 @@
 #!/usr/bin/python3
-# SPDX-FileCopyrightText: 2021 Damon Lynch <damonlynch@gmail.com>
+# SPDX-FileCopyrightText: 2021-2024 Damon Lynch <damonlynch@gmail.com>
 # SPDX-License-Identifier: MIT
 
-__author__ = "Damon Lynch"
-__copyright__ = "Copyright 2021-2024, Damon Lynch"
 
 from showinfm.showinfm import main
 

--- a/src/rundoctest.py
+++ b/src/rundoctest.py
@@ -1,10 +1,12 @@
 #!/usr/bin/python3
-# SPDX-FileCopyrightText: 2021-2024 Damon Lynch <damonlynch@gmail.com>
-# SPDX-License-Identifier: MIT
+#  SPDX-FileCopyrightText: 2021-2026 Damon Lynch <damonlynch@gmail.com>
+#  SPDX-License-Identifier: MIT
 
 import doctest
+import platform
 
 from showinfm.system.linux import wsl_transform_path_uri
 
 if __name__ == "__main__":
-    doctest.run_docstring_examples(wsl_transform_path_uri, globals())
+    if platform.system() == "Linux":
+        doctest.run_docstring_examples(wsl_transform_path_uri, globals())

--- a/src/showinfm/showinfm.py
+++ b/src/showinfm/showinfm.py
@@ -1,5 +1,5 @@
-# SPDX-FileCopyrightText: 2016-2024 Damon Lynch <damonlynch@gmail.com>
-# SPDX-License-Identifier: MIT
+#  SPDX-FileCopyrightText: 2016-2026 Damon Lynch <damonlynch@gmail.com>
+#  SPDX-License-Identifier: MIT
 
 """
 Show in File Manager
@@ -9,7 +9,7 @@ Open the system file manager and optionally select files in it.
 
 import shutil
 import sys
-from typing import Optional, Sequence, Union
+from collections.abc import Sequence
 
 import showinfm.filemanager
 from showinfm.argumentsparse import get_parser
@@ -92,9 +92,9 @@ def valid_file_manager() -> str:
 
 
 def show_in_file_manager(
-    path_or_uri: Optional[Union[str, Sequence[str]]] = None,
+    path_or_uri: str | Sequence[str] | None = None,
     open_not_select_directory: bool = True,
-    file_manager: Optional[str] = None,
+    file_manager: str | None = None,
     allow_conversion: bool = True,
     verbose: bool = False,
     debug: bool = False,
@@ -168,7 +168,7 @@ class Diagnostics:
     """
 
     def __init__(self) -> None:
-        self.desktop: Optional[linux.LinuxDesktop]
+        self.desktop: linux.LinuxDesktop | None
         self.wsl_version: str
 
         try:

--- a/src/showinfm/system/__init__.py
+++ b/src/showinfm/system/__init__.py
@@ -1,13 +1,12 @@
-# SPDX-FileCopyrightText: 2021-2024 Damon Lynch <damonlynch@gmail.com>
-# SPDX-License-Identifier: MIT
+#  SPDX-FileCopyrightText: 2021-2026 Damon Lynch <damonlynch@gmail.com>
+#  SPDX-License-Identifier: MIT
 
 import platform
-from typing import Union
 
 from ..constants import Platform
 from . import linux
 
-current_platform: Union[Platform, None]
+current_platform: Platform | None
 system = platform.system()
 is_wsl: bool = False
 is_wsl1: bool = False

--- a/src/showinfm/system/linux.py
+++ b/src/showinfm/system/linux.py
@@ -4,7 +4,6 @@
 
 import functools
 import os
-import packaging.version
 import re
 import shlex
 import shutil
@@ -12,8 +11,10 @@ import subprocess
 import urllib.request
 from enum import Enum
 from pathlib import Path, PureWindowsPath
-from typing import NamedTuple, Optional, Tuple
+from typing import NamedTuple, Optional
 from urllib.parse import unquote, urlparse
+
+import packaging.version
 
 try:
     import xdg  # type: ignore
@@ -148,7 +149,7 @@ def valid_linux_file_manager() -> str:
         return ""
 
 
-def known_linux_file_managers() -> Tuple[str, ...]:
+def known_linux_file_managers() -> tuple[str, ...]:
     """
     Generate a collection of Linux file managers this module knows about
 
@@ -171,7 +172,7 @@ def linux_file_manager_type(file_manager: str) -> FileManagerType:
     return LinuxFileManagerBehavior.get(file_manager, FileManagerType.regular)
 
 
-def caja_version() -> Optional[packaging.version.Version]:
+def caja_version() -> packaging.version.Version | None:
     """
     Get the version of Caja via a command line switch
     :return: parsed ver
@@ -190,7 +191,7 @@ def caja_version() -> Optional[packaging.version.Version]:
     if result is None:
         return None
 
-    version = version_string[result.start():]
+    version = version_string[result.start() :]
     return packaging.version.parse(version)
 
 
@@ -262,16 +263,16 @@ def wsl_path_is_for_windows(path_or_uri: str) -> bool:
 
 
 class WSLTransformPathURI(NamedTuple):
-    is_win_location: Optional[bool]
-    win_uri: Optional[str]
-    win_path: Optional[str]
-    linux_path: Optional[str]
-    is_dir: Optional[bool]
+    is_win_location: bool | None
+    win_uri: str | None
+    win_path: str | None
+    linux_path: str | None
+    is_dir: bool | None
     exists: bool
 
 
 def wsl_transform_path_uri(
-        path_or_uri: str, generate_win_path: bool
+    path_or_uri: str, generate_win_path: bool
 ) -> WSLTransformPathURI:
     r"""
     Transforms URI or path into path and URI suitable for working with WSL.
@@ -526,10 +527,10 @@ def wsl_transform_path_uri(
     >>> os.chdir(cwd)
     """
 
-    win_uri: Optional[str] = None
-    win_path: Optional[str] = None
-    linux_path: Optional[str] = None
-    is_dir: Optional[bool] = None
+    win_uri: str | None = None
+    win_path: str | None = None
+    linux_path: str | None = None
+    is_dir: bool | None = None
     exists: bool = False
 
     if path_or_uri.startswith("file:/"):
@@ -747,7 +748,7 @@ LinuxFileManagerBehavior["lumina-fm"] = FileManagerType.dir_only_uri
 LinuxFileManagerBehavior["cosmic-files"] = FileManagerType.regular
 
 
-def wsl_version() -> Optional[LinuxDesktop]:
+def wsl_version() -> LinuxDesktop | None:
     with open("/proc/version") as f:
         p = f.read()
     if p.find("microsoft") > 0 and p.find("WSL2"):
@@ -763,7 +764,7 @@ def detect_wsl() -> bool:
     return p.lower().find("microsoft") > 0
 
 
-@functools.lru_cache(maxsize=None)
+@functools.cache
 def linux_desktop() -> LinuxDesktop:
     """
     Determine Linux desktop environment

--- a/src/showinfm/system/tools.py
+++ b/src/showinfm/system/tools.py
@@ -1,13 +1,12 @@
-# SPDX-FileCopyrightText: 2021-2024 Damon Lynch <damonlynch@gmail.com>
-# SPDX-FileCopyrightText: 2008-2021 The pip developers
-# SPDX-License-Identifier: MIT
+#  SPDX-FileCopyrightText: 2008-2026 Damon Lynch <damonlynch@gmail.com>
+#  SPDX-FileCopyrightText: 2008-2021 The pip developers
+#  SPDX-License-Identifier: MIT
 
 import os
 import re
 import shlex
 from collections import defaultdict
 from pathlib import Path
-from typing import DefaultDict, List
 from urllib.parse import urljoin, urlparse
 from urllib.request import pathname2url, url2pathname
 
@@ -43,7 +42,6 @@ def quote_path(path: Path) -> Path:
     not already quoted.
 
     :param path: path to quote, if necessary
-    :param target_platform: platform the file manager command will be executed on
     :return: double-quoted path
     """
 
@@ -94,7 +92,7 @@ def file_uri_to_path(uri: str) -> str:
     return p
 
 
-def directories_and_their_files(paths: List[str]) -> DefaultDict[str, List[str]]:
+def directories_and_their_files(paths: list[str]) -> defaultdict[str, list[str]]:
     """
     Group paths into directories and their files.
 

--- a/src/showinfm/system/windows.py
+++ b/src/showinfm/system/windows.py
@@ -1,12 +1,13 @@
-# SPDX-FileCopyrightText: 2021-2024 Damon Lynch <damonlynch@gmail.com>
-# SPDX-License-Identifier: MIT
+#  SPDX-FileCopyrightText: 2021-2026 Damon Lynch <damonlynch@gmail.com>
+#  SPDX-License-Identifier: MIT
 
 import contextlib
 from pathlib import Path
-from typing import List, Optional
 
 with contextlib.suppress(ImportError):
     from win32com.shell import shell
+
+import os
 
 from showinfm.constants import FileManagerType
 from showinfm.system.tools import (
@@ -16,11 +17,10 @@ from showinfm.system.tools import (
     path_to_file_uri,
 )
 
-import os
-
-WindowsFileManagerBehavior = {}
-WindowsFileManagerBehavior["doublecmd.exe"] = FileManagerType.dual_panel
-WindowsFileManagerBehavior["fman.exe"] = FileManagerType.dual_panel
+WindowsFileManagerBehavior = {
+    "doublecmd.exe": FileManagerType.dual_panel,
+    "fman.exe": FileManagerType.dual_panel,
+}
 
 
 def windows_file_manager_type(file_manager: str) -> FileManagerType:
@@ -36,7 +36,7 @@ def windows_file_manager_type(file_manager: str) -> FileManagerType:
     return WindowsFileManagerBehavior.get(file_manager, FileManagerType.regular)
 
 
-def parse_command_line_arguments(path_or_uri: List[str]) -> List[str]:
+def parse_command_line_arguments(path_or_uri: list[str]) -> list[str]:
     """
     Convert any glob component in the filename component of Windows paths, which the
     Windows shell does not do itself
@@ -68,12 +68,12 @@ def parse_command_line_arguments(path_or_uri: List[str]) -> List[str]:
     return paths
 
 
-def launch_file_explorer(paths: List[str], verbose: Optional[bool] = False) -> None:
+def launch_file_explorer(paths: list[str], verbose: bool | None = False) -> None:
     """
     Open Windows File Explorer, selecting files in their folders
 
     Inspired by https://mail.python.org/pipermail/python-win32/2012-September/012531.html
-    and http://mail.python.org/pipermail/python-win32/2012-September/012533.html
+    and https://mail.python.org/pipermail/python-win32/2012-September/012533.html
 
     See also:
     https://learn.microsoft.com/en-us/windows/win32/api/shlobj_core/nf-shlobj_core-shopenfolderandselectitems
@@ -87,7 +87,10 @@ def launch_file_explorer(paths: List[str], verbose: Optional[bool] = False) -> N
                 files = '", "'.join(folder_contents[folder])
                 if files:
                     files = f'"{files}"'
-                print("Executing Windows shell to open file " f'explorer at "{folder}", selecting {files}')
+                print(
+                    "Executing Windows shell to open file "
+                    f'explorer at "{folder}", selecting {files}'
+                )
             to_select = [
                 shell.SHParseDisplayName(os.path.join(folder, filename), 0, None)[0]
                 for filename in folder_contents[folder]


### PR DESCRIPTION
Summary
- Adopt modern Python 3.10+ typing throughout the codebase (PEP 604 unions and collections.abc types).
- Replace legacy typing imports with inline union syntax (e.g., str | Sequence[str], list[str], Path | None) and convert Optional/Union usages to X | None.
- Use collections.abc.Sequence instead of typing.Sequence for consistency.
- Update SPDX copyright years to 2026 across several modules.
- Tighten runtime behavior for doctests: only run rundoctest.py on Linux by checking platform.system().
- Minor code cleanups for clarity and type consistency in FileManager and showinfm interfaces.
- Update PyCharm configuration files.