### PR TITLE
dl-branch-2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,15 +1,21 @@
 Changelog for Show in File Manager
 ==================================
 
-1.1.6 (2026-02-xx)
+1.1.6 (2026-02-16)
 ------------------
 
 - Support [Cosmic Files](https://github.com/pop-os/cosmic-files)
 - Add check for "kde:plasma" in environment variable
   XDG_CURRENT_DESKTOP.
 - Fix [#27](https://github.com/damonlynch/showinfilemanager/issues/27):
-  Incorrect behavior when Windows explorer hides file extensions.
+  Incorrect behavior when Windows explorer hides file extensions. Thanks to
+  tpl2go for the fix.
 - Drop Python 3.8 and 3.9 support. Use Python 3.10+ typing syntax.
+- Add `__version__` to package.
+- `hatch build -t sdist` now produces an archive of the project's
+  source code.
+- `hatch build -t wheel` now produces a wheel (zip archive) of
+  the program's Python code; it also generates the manpage.
 
 1.1.6a1 (2024-04-18)
 --------------------

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,117 +3,141 @@ Changelog for Show in File Manager
 
 1.1.6 (2026-02-xx)
 ------------------
- - Support [Cosmic Files](https://github.com/pop-os/cosmic-files)
- - Add check for "kde:plasma" in environment variable
-   XDG_CURRENT_DESKTOP.
+
+- Support [Cosmic Files](https://github.com/pop-os/cosmic-files)
+- Add check for "kde:plasma" in environment variable
+  XDG_CURRENT_DESKTOP.
+- Fix [#27](https://github.com/damonlynch/showinfilemanager/issues/27):
+  Incorrect behavior when Windows explorer hides file extensions.
+- Drop Python 3.8 and 3.9 support. Use Python 3.10+ typing syntax.
 
 1.1.6a1 (2024-04-18)
 --------------------
- - Update SPDX headers to be compliant with spec.
- - Switch to [hatch](https://hatch.pypa.io/latest/) from setuptools.
- - New build dependency: [hatch-argparse-manpage](https://github.com/damonlynch/hatch-argparse-manpage).
- - Add [Release Notes](RELEASE_NOTES.md).
- - Refactor: use absolute imports, not relative.
- - Refactor: flatten code by using a new class. The API is unchanged.
+
+- Update SPDX headers to be compliant with spec.
+- Switch to [hatch](https://hatch.pypa.io/latest/) from setuptools.
+- New build
+  dependency: [hatch-argparse-manpage](https://github.com/damonlynch/hatch-argparse-manpage).
+- Add [Release Notes](RELEASE_NOTES.md).
+- Refactor: use absolute imports, not relative.
+- Refactor: flatten code by using a new class. The API is unchanged.
 
 1.1.5 (2024-03-06)
 ------------------
- - Drop setup.py and setup.cfg in favor of pyproject.toml.
- - Purge doc directory.
- - New build dependency: [argparse-manpage](https://github.com/praiskup/argparse-manpage)
- - Generate man page with argparse-manpage instead of pandoc.
- - Format and lint using ruff. Drop black.
- - Drop Python 3.6 and 3.7 support.
+
+- Drop setup.py and setup.cfg in favor of pyproject.toml.
+- Purge doc directory.
+- New build
+  dependency: [argparse-manpage](https://github.com/praiskup/argparse-manpage)
+- Generate man page with argparse-manpage instead of pandoc.
+- Format and lint using ruff. Drop black.
+- Drop Python 3.6 and 3.7 support.
 
 1.1.4 (2022-03-04)
 ------------------
- - Move debian directory into doc
+
+- Move debian directory into doc
 
 1.1.3 (2022-02-18)
 ------------------
- - Fix bug [#3](https://github.com/damonlynch/showinfilemanager/issues/3):
-   Missing dependency on packaging.
+
+- Fix bug [#3](https://github.com/damonlynch/showinfilemanager/issues/3):
+  Missing dependency on packaging.
 
 1.1.2 (2021-12-27)
 ------------------
- - Add check for "unity:unity7:ubuntu" in environment variable
-   XDG_CURRENT_DESKTOP. 
-   See https://github.com/damonlynch/rapid-photo-downloader/issues/46.
+
+- Add check for "unity:unity7:ubuntu" in environment variable
+  XDG_CURRENT_DESKTOP.
+  See https://github.com/damonlynch/rapid-photo-downloader/issues/46.
 
 1.1.1 (2021-10-31)
 ------------------
- - Add `allow_conversion` switch to `show_in_file_manager()`. Set to False 
-   if passing non-standard URIs.
- - Recognize non-standard URI prefix 'camera:/', used by KDE.
- - Added function `linux_desktop_humanize()`, to make Linux desktop environment 
-   variable name values human friendly.
+
+- Add `allow_conversion` switch to `show_in_file_manager()`. Set to False
+  if passing non-standard URIs.
+- Recognize non-standard URI prefix 'camera:/', used by KDE.
+- Added function `linux_desktop_humanize()`, to make Linux desktop environment
+  variable name values human friendly.
 
 1.1.0 (2021-10-29)
 ------------------
- - On WSL2, use a Linux file manager (if set) for WSL paths, and Windows 
-   Explorer for Windows paths. If no Linux file manager is installed, use 
-   Windows Explorer. To override the default choice of using Explorer for 
-   Windows paths, simply specify a file manager of your choice.
- - On both WSL1 and WSL2, use Windows style URIs to work around a
-   [bug](https://github.com/microsoft/WSL/issues/7603) in WSL where using 
-   the /select switch while passing a path with spaces in it fails.
- - Don't mess up the terminal when launching Windows Explorer from WSL 
-   on Windows Terminal.
- 
+
+- On WSL2, use a Linux file manager (if set) for WSL paths, and Windows
+  Explorer for Windows paths. If no Linux file manager is installed, use
+  Windows Explorer. To override the default choice of using Explorer for
+  Windows paths, simply specify a file manager of your choice.
+- On both WSL1 and WSL2, use Windows style URIs to work around a
+  [bug](https://github.com/microsoft/WSL/issues/7603) in WSL where using
+  the /select switch while passing a path with spaces in it fails.
+- Don't mess up the terminal when launching Windows Explorer from WSL
+  on Windows Terminal.
+
 1.0.1 (2021-10-23)
 -----------------
- - Reformat code with black.
+
+- Reformat code with black.
 
 1.0.0 (2021-10-04)
 ------------------
- - Support [Lumina](https://lumina-desktop.org/).
+
+- Support [Lumina](https://lumina-desktop.org/).
 
 0.9.0 (2021-09-08)
 ------------------
- - Add option to specify file manager to use from command line.
- - Support [Double Commander](https://doublecmd.sourceforge.io/).
- - Support [Krusader](https://krusader.org/).
- - Support [SpaceFM](https://ignorantguru.github.io/spacefm/).
- - Support [fman](https://fman.io/).
+
+- Add option to specify file manager to use from command line.
+- Support [Double Commander](https://doublecmd.sourceforge.io/).
+- Support [Krusader](https://krusader.org/).
+- Support [SpaceFM](https://ignorantguru.github.io/spacefm/).
+- Support [fman](https://fman.io/).
 
 0.0.8 (2021-08-31)
 ------------------
- - Support [CutefishOS](https://en.cutefishos.com/).
- - Support [Index File Manager](https://invent.kde.org/maui/index-fm).
+
+- Support [CutefishOS](https://en.cutefishos.com/).
+- Support [Index File Manager](https://invent.kde.org/maui/index-fm).
 
 0.0.7 (2021-08-20)
 ------------------
- - Use `--select` command line switch in caja 1.26 or newer.
+
+- Use `--select` command line switch in caja 1.26 or newer.
 
 0.0.6 (2021-08-19)
 ------------------
- - Remove get_ prefix from package level function names.
+
+- Remove get_ prefix from package level function names.
 
 0.0.5 (2021-08-19)
 ------------------
- - Add setup.py for man page generation.
- - Improve README to clarify installation and usage.
- - Parse filename globs passed via the command line on Windows.
- - Use win32 API to execute explorer.exe on Windows, allowing for
-   multiple file selection.
+
+- Add setup.py for man page generation.
+- Improve README to clarify installation and usage.
+- Parse filename globs passed via the command line on Windows.
+- Use win32 API to execute explorer.exe on Windows, allowing for
+  multiple file selection.
 
 0.0.4 (2021-08-14)
 ------------------
- - Update README to include installation instructions.
- - Include CHANGELOG.md in package.
- - Generate man page for use in Linux.
- - Improve command line argument documentation.
+
+- Update README to include installation instructions.
+- Include CHANGELOG.md in package.
+- Generate man page for use in Linux.
+- Improve command line argument documentation.
 
 0.0.3 (2021-08-12)
 ------------------
- - Update README.
+
+- Update README.
 
 0.0.2 (2021-08-12)
 ------------------
- - Move config data from `__about__.py` to static config in 
-   `pyproject.toml` [(PEP 621)](https://www.python.org/dev/peps/pep-0621/).
- - Added command line arguments `--debug` and `--verbose`.
+
+- Move config data from `__about__.py` to static config in
+  `pyproject.toml` [(PEP 621)](https://www.python.org/dev/peps/pep-0621/).
+- Added command line arguments `--debug` and `--verbose`.
 
 0.0.1 (2021-08-12)
 ------------------
- - Initial release.
+
+- Initial release.

--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ one function, the function `show_in_file_manager`, and it should just work.
 This package aspires to be platform independent, but it currently supports
 only Windows 10/11, Linux,
 [WSL1 and WSL2](https://docs.microsoft.com/en-us/windows/wsl/), and macOS.
-It works with 19 [supported file managers](#supported-file-managers).
+It works with 20 [supported file managers](#supported-file-managers).
 
 ## Install and run
 

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,9 +1,14 @@
 Release Notes for Show in File Manager 1.1.6
 ============================================
 
- - Show in File Manager 1.1.6 switches its build system from `setuptools` to 
-   [Hatch](https://github.com/pypa/hatch).
+- Show in File Manager 1.1.6 switches its build system from `setuptools` to
+  [Hatch](https://github.com/pypa/hatch).
+    - `hatch build -t sdist` now produces an archive of the project's
+      source code.
+    - `hatch build -t wheel` now produces a wheel (zip archive) of
+      the program's Python code; it also generates the manpage.
 
- - To generate the manpage, a new plugin [Hatch-argparse-manpage](https://github.com/damonlynch/hatch-argparse-manpage) 
-   is used, which is a new build-time dependency. This plugin can be used 
-   with any Hatch project, not just Show in File Manager. 
+- To generate the manpage, a new
+  plugin [Hatch-argparse-manpage](https://github.com/damonlynch/hatch-argparse-manpage)
+  is used, which is a new build-time dependency. This plugin can be used
+  with any Hatch project, not just Show in File Manager. 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -44,12 +44,13 @@ showinfilemanager = "showinfm.showinfm:main"
 path = "src/showinfm/__about__.py"
 
 [tool.hatch.build.targets.sdist]
-packages = ["src/showinfm"]
+include = ["src/showinfm", "/*.md"]
+exclude = [".github"]
 
 [tool.hatch.build.targets.wheel]
-packages = ["src/showinfm"]
+packages = ["src/showinfm", "man", "/*.md"]
 
-[tool.hatch.build.hooks.argparse-manpage]
+[tool.hatch.build.targets.wheel.hooks.argparse-manpage]
 include-url = false
 manpages = [
     "man/showinfilemanager.1:function=get_parser:pyfile=src/showinfm/argumentsparse.py:manual_title=General Commands Manual",

--- a/src/showinfm/__init__.py
+++ b/src/showinfm/__init__.py
@@ -1,8 +1,10 @@
-# SPDX-FileCopyrightText: 2021 Damon Lynch <damonlynch@gmail.com>
-# SPDX-License-Identifier: MIT
+#  SPDX-FileCopyrightText: 2021-2026 Damon Lynch <damonlynch@gmail.com>
+#  SPDX-License-Identifier: MIT
 
 # ruff: noqa: F401
 
+
+from showinfm.__about__ import __version__
 from showinfm.constants import cannot_open_uris, single_file_only
 from showinfm.showinfm import (
     show_in_file_manager,

--- a/src/showinfm/argumentsparse.py
+++ b/src/showinfm/argumentsparse.py
@@ -1,5 +1,5 @@
-# SPDX-FileCopyrightText: 2016-2024 Damon Lynch <damonlynch@gmail.com>
-# SPDX-License-Identifier: MIT
+#  SPDX-FileCopyrightText: 2016-2026 Damon Lynch <damonlynch@gmail.com>
+#  SPDX-License-Identifier: MIT
 
 """
 Parse command line arguments
@@ -7,29 +7,43 @@ Parse command line arguments
 
 import importlib.metadata
 from argparse import ArgumentParser, HelpFormatter
+from pathlib import Path
+
+try:
+    from showinfm import __about__ as __about__
+except ImportError:
+    # The script is being run at build time
+    # Module imports are unavailable
+
+    here = Path(__file__).parent
+    with open(here / "__about__.py") as f:
+        about = {}
+        exec(f.read(), about)
+
+    # Convert about dictionary to class
+    class About:
+        pass
+
+    __about__ = About()
+    __about__.__dict__.update(about)
 
 
 def package_metadata():
     """
     Get Python package metadata
 
-    :return: version number and package summary
+    :return: package summary
     """
 
     try:
-        version = importlib.metadata.version("show-in-file-manager")
+        metadata = importlib.metadata.metadata("show-in-file-manager")
+        summary = metadata["summary"]
     except Exception:
-        version = "Unknown version"
         summary = (
             "Platform independent Python module to open the system file manager "
             "and optionally select files in it "
         )
-
-    else:
-        metadata = importlib.metadata.metadata("show-in-file-manager")
-        summary = metadata["summary"]
-
-    return version, summary
+    return summary
 
 
 def get_parser(formatter_class=HelpFormatter) -> ArgumentParser:
@@ -40,13 +54,15 @@ def get_parser(formatter_class=HelpFormatter) -> ArgumentParser:
     :return: argparse.ArgumentParser
     """
 
-    version, summary = package_metadata()
+    summary = package_metadata()
 
     parser = ArgumentParser(
         prog="showinfilemanager", description=summary, formatter_class=formatter_class
     )
 
-    parser.add_argument("--version", action="version", version=f"%(prog)s {version}")
+    parser.add_argument(
+        "--version", action="version", version=f"%(prog)s {__about__.__version__}"
+    )
 
     parser.add_argument("-f", "--file-manager", help="file manager to run")
 

--- a/src/showinfm/filemanager.py
+++ b/src/showinfm/filemanager.py
@@ -275,13 +275,7 @@ class FileManager:
                 uri = Path(pu).resolve().as_uri()
                 path = None
 
-        has_error = not (
-            path.exists() if path else Path(tools.file_uri_to_path(pu)).exists()
-        )
-        if has_error and self.debug:
-            print(f"Path '{path}' does not exist", file=sys.stderr)
-
-        return ProcessPathOrUri(fully_processed=has_error, path=path, uri=uri)
+        return ProcessPathOrUri(fully_processed=False, path=path, uri=uri)
 
     def _process_path_or_uri_no_select(
         self, path: Path | None, uri: str | None


### PR DESCRIPTION
### What changed

- Tidy CHANGELOG formatting; add Windows Explorer-hide-extension fix and note dropping Python 3.8/3.9 (adopt Python 3.10+ typing).
- Revert buggy path-existence validation and debug logging in _process_path_or_uri; always return ProcessPathOrUri with fully_processed = False and keep resolved path/uri.