### PR TITLE
docs: reformat and remove hard word wrap

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,24 +1,19 @@
-Changelog for Show in File Manager
-==================================
+# Changelog for Show in File Manager
 
-1.1.6 (2026-02-16)
-------------------
+## 1.1.6 (2026-02-16)
 
 - Support [Cosmic Files](https://github.com/pop-os/cosmic-files)
-- Add check for "kde:plasma" in environment variable
-  XDG_CURRENT_DESKTOP.
+- Add check for "kde:plasma" in environment variable `XDG_CURRENT_DESKTOP`.
 - Fix [#27](https://github.com/damonlynch/showinfilemanager/issues/27):
   Incorrect behavior when Windows explorer hides file extensions. Thanks to
   tpl2go for the fix.
 - Drop Python 3.8 and 3.9 support. Use Python 3.10+ typing syntax.
 - Add `__version__` to package.
-- `hatch build -t sdist` now produces an archive of the project's
-  source code.
-- `hatch build -t wheel` now produces a wheel (zip archive) of
-  the program's Python code; it also generates the manpage.
+- `hatch build -t sdist` now produces an archive of the project's source code.
+- `hatch build -t wheel` now produces a wheel (zip archive) of the program's
+  Python code; it also generates the manpage.
 
-1.1.6a1 (2024-04-18)
---------------------
+## 1.1.6a1 (2024-04-18)
 
 - Update SPDX headers to be compliant with spec.
 - Switch to [hatch](https://hatch.pypa.io/latest/) from setuptools.
@@ -28,8 +23,7 @@ Changelog for Show in File Manager
 - Refactor: use absolute imports, not relative.
 - Refactor: flatten code by using a new class. The API is unchanged.
 
-1.1.5 (2024-03-06)
-------------------
+## 1.1.5 (2024-03-06)
 
 - Drop setup.py and setup.cfg in favor of pyproject.toml.
 - Purge doc directory.
@@ -39,58 +33,50 @@ Changelog for Show in File Manager
 - Format and lint using ruff. Drop black.
 - Drop Python 3.6 and 3.7 support.
 
-1.1.4 (2022-03-04)
-------------------
+## 1.1.4 (2022-03-04)
 
 - Move debian directory into doc
 
-1.1.3 (2022-02-18)
-------------------
+## 1.1.3 (2022-02-18)
 
-- Fix bug [#3](https://github.com/damonlynch/showinfilemanager/issues/3):
-  Missing dependency on packaging.
+- Fix [#3](https://github.com/damonlynch/showinfilemanager/issues/3): Missing
+  dependency on packaging.
 
-1.1.2 (2021-12-27)
-------------------
+## 1.1.2 (2021-12-27)
 
 - Add check for "unity:unity7:ubuntu" in environment variable
   XDG_CURRENT_DESKTOP.
   See https://github.com/damonlynch/rapid-photo-downloader/issues/46.
 
-1.1.1 (2021-10-31)
-------------------
+## 1.1.1 (2021-10-31)
 
-- Add `allow_conversion` switch to `show_in_file_manager()`. Set to False
-  if passing non-standard URIs.
+- Add `allow_conversion` switch to `show_in_file_manager()`. Set to False if
+  passing non-standard URIs.
 - Recognize non-standard URI prefix 'camera:/', used by KDE.
 - Added function `linux_desktop_humanize()`, to make Linux desktop environment
   variable name values human friendly.
 
-1.1.0 (2021-10-29)
-------------------
+## 1.1.0 (2021-10-29)
 
-- On WSL2, use a Linux file manager (if set) for WSL paths, and Windows
-  Explorer for Windows paths. If no Linux file manager is installed, use
-  Windows Explorer. To override the default choice of using Explorer for
-  Windows paths, simply specify a file manager of your choice.
-- On both WSL1 and WSL2, use Windows style URIs to work around a
-  [bug](https://github.com/microsoft/WSL/issues/7603) in WSL where using
-  the /select switch while passing a path with spaces in it fails.
-- Don't mess up the terminal when launching Windows Explorer from WSL
-  on Windows Terminal.
+- On WSL2, use a Linux file manager (if set) for WSL paths, and Windows Explorer
+  for Windows paths. If no Linux file manager is installed, use Windows
+  Explorer. To override the default choice of using Explorer for Windows paths,
+  simply specify a file manager of your choice.
+- On both WSL1 and WSL2, use Windows style URIs to work around
+  a [bug](https://github.com/microsoft/WSL/issues/7603) in WSL where using the
+  /select switch while passing a path with spaces in it fails.
+- Don't mess up the terminal when launching Windows Explorer from WSL on Windows
+  Terminal.
 
-1.0.1 (2021-10-23)
------------------
+## 1.0.1 (2021-10-23)
 
 - Reformat code with black.
 
-1.0.0 (2021-10-04)
-------------------
+## 1.0.0 (2021-10-04)
 
 - Support [Lumina](https://lumina-desktop.org/).
 
-0.9.0 (2021-09-08)
-------------------
+## 0.9.0 (2021-09-08)
 
 - Add option to specify file manager to use from command line.
 - Support [Double Commander](https://doublecmd.sourceforge.io/).
@@ -98,52 +84,44 @@ Changelog for Show in File Manager
 - Support [SpaceFM](https://ignorantguru.github.io/spacefm/).
 - Support [fman](https://fman.io/).
 
-0.0.8 (2021-08-31)
-------------------
+## 0.0.8 (2021-08-31)
 
 - Support [CutefishOS](https://en.cutefishos.com/).
 - Support [Index File Manager](https://invent.kde.org/maui/index-fm).
 
-0.0.7 (2021-08-20)
-------------------
+## 0.0.7 (2021-08-20)
 
 - Use `--select` command line switch in caja 1.26 or newer.
 
-0.0.6 (2021-08-19)
-------------------
+## 0.0.6 (2021-08-19)
 
-- Remove get_ prefix from package level function names.
+- Remove get\_ prefix from package level function names.
 
-0.0.5 (2021-08-19)
-------------------
+## 0.0.5 (2021-08-19)
 
 - Add setup.py for man page generation.
 - Improve README to clarify installation and usage.
 - Parse filename globs passed via the command line on Windows.
-- Use win32 API to execute explorer.exe on Windows, allowing for
-  multiple file selection.
+- Use win32 API to execute explorer.exe on Windows, allowing for multiple file
+  selection.
 
-0.0.4 (2021-08-14)
-------------------
+## 0.0.4 (2021-08-14)
 
 - Update README to include installation instructions.
 - Include CHANGELOG.md in package.
 - Generate man page for use in Linux.
 - Improve command line argument documentation.
 
-0.0.3 (2021-08-12)
-------------------
+## 0.0.3 (2021-08-12)
 
 - Update README.
 
-0.0.2 (2021-08-12)
-------------------
+## 0.0.2 (2021-08-12)
 
 - Move config data from `__about__.py` to static config in
   `pyproject.toml` [(PEP 621)](https://www.python.org/dev/peps/pep-0621/).
 - Added command line arguments `--debug` and `--verbose`.
 
-0.0.1 (2021-08-12)
-------------------
+## 0.0.1 (2021-08-12)
 
 - Initial release.

--- a/README.md
+++ b/README.md
@@ -1,39 +1,25 @@
 # Show in File Manager
 
 |         |                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                             |
-|---------|---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
-| Package | [![PyPI - Version](https://img.shields.io/pypi/v/show-in-file-manager.svg)](https://pypi.org/project/show-in-file-manager) [![PyPI - Python Version](https://img.shields.io/pypi/pyversions/show-in-file-manager.svg?logo=python&label=Python&logoColor=gold)](https://pypi.org/project/show-in-file-manager/)                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                              | 
+| ------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| Package | [![PyPI - Version](https://img.shields.io/pypi/v/show-in-file-manager.svg)](https://pypi.org/project/show-in-file-manager) [![PyPI - Python Version](https://img.shields.io/pypi/pyversions/show-in-file-manager.svg?logo=python&label=Python&logoColor=gold)](https://pypi.org/project/show-in-file-manager/)                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                              |
 | Meta    | [![Hatch project](https://img.shields.io/badge/%F0%9F%A5%9A-Hatch-4051b5.svg)](https://github.com/pypa/hatch) [![Ruff](https://img.shields.io/endpoint?url=https://raw.githubusercontent.com/astral-sh/ruff/main/assets/badge/v2.json)](https://github.com/astral-sh/ruff) [![GitButler](https://img.shields.io/badge/GitButler-%23B9F4F2?logo=data%3Aimage%2Fsvg%2Bxml%3Bbase64%2CPHN2ZyB3aWR0aD0iMzkiIGhlaWdodD0iMjgiIHZpZXdCb3g9IjAgMCAzOSAyOCIgZmlsbD0ibm9uZSIgeG1sbnM9Imh0dHA6Ly93d3cudzMub3JnLzIwMDAvc3ZnIj4KPHBhdGggZD0iTTI1LjIxNDUgMTIuMTk5N0wyLjg3MTA3IDEuMzg5MTJDMS41NDI5NSAwLjc0NjUzMiAwIDEuNzE0MDYgMCAzLjE4OTQ3VjI0LjgxMDVDMCAyNi4yODU5IDEuNTQyOTUgMjcuMjUzNSAyLjg3MTA3IDI2LjYxMDlMMjUuMjE0NSAxNS44MDAzQzI2LjcxOTcgMTUuMDcyMSAyNi43MTk3IDEyLjkyNzkgMjUuMjE0NSAxMi4xOTk3WiIgZmlsbD0iYmxhY2siLz4KPHBhdGggZD0iTTEzLjc4NTUgMTIuMTk5N0wzNi4xMjg5IDEuMzg5MTJDMzcuNDU3MSAwLjc0NjUzMiAzOSAxLjcxNDA2IDM5IDMuMTg5NDdWMjQuODEwNUMzOSAyNi4yODU5IDM3LjQ1NzEgMjcuMjUzNSAzNi4xMjg5IDI2LjYxMDlMMTMuNzg1NSAxNS44MDAzQzEyLjI4MDMgMTUuMDcyMSAxMi4yODAzIDEyLjkyNzkgMTMuNzg1NSAxMi4xOTk3WiIgZmlsbD0idXJsKCNwYWludDBfcmFkaWFsXzMxMF8xMjkpIi8%2BCjxkZWZzPgo8cmFkaWFsR3JhZGllbnQgaWQ9InBhaW50MF9yYWRpYWxfMzEwXzEyOSIgY3g9IjAiIGN5PSIwIiByPSIxIiBncmFkaWVudFVuaXRzPSJ1c2VyU3BhY2VPblVzZSIgZ3JhZGllbnRUcmFuc2Zvcm09InRyYW5zbGF0ZSgxNi41NzAxIDE0KSBzY2FsZSgxOS44NjQxIDE5LjgzODMpIj4KPHN0b3Agb2Zmc2V0PSIwLjMwMTA1NiIgc3RvcC1vcGFjaXR5PSIwIi8%2BCjxzdG9wIG9mZnNldD0iMSIvPgo8L3JhZGlhbEdyYWRpZW50Pgo8L2RlZnM%2BCjwvc3ZnPgo%3D)](https://gitbutler.com/) [![Checked with mypy](http://www.mypy-lang.org/static/mypy_badge.svg)](http://mypy-lang.org/) [![License - MIT](https://img.shields.io/badge/license-MIT-9400d3.svg)](https://spdx.org/licenses/) [![GitHub Sponsors](https://img.shields.io/github/sponsors/damonlynch?logo=GitHub%20Sponsors&style=social)](https://github.com/sponsors/damonlynch) |
 
------
+______________________________________________________________________
 
-**Show in File Manager** is a Python package to open the system file manager
-and optionally select files in it. The point is not to _open_ the files,
-but to _select_ them in the file manager, thereby highlighting the
-files and allowing the user to quickly do something with them.
+**Show in File Manager** is a Python package to open the system file manager and optionally select files in it. The point is not to _open_ the files, but to _select_ them in the file manager, thereby highlighting the files and allowing the user to quickly do something with them.
 
-Plenty of programs expose this functionality in their user interface. On
-Windows terms like "Show in Windows Explorer", "Show in Explorer", and
-"Reveal in Explorer" are common. Cross-platform programs use terms like "Open
-Containing Folder" or "Open in File Browser", all doing something similar:
+Plenty of programs expose this functionality in their user interface. On Windows terms like "Show in Windows Explorer", "Show in Explorer", and "Reveal in Explorer" are common. Cross-platform programs use terms like "Open Containing Folder" or "Open in File Browser", all doing something similar:
 
-![Show in Windows Explorer](https://github.com/damonlynch/showinfilemanager/raw/main/.github/photomechanic-win.png)
-![Open containing folder](https://github.com/damonlynch/showinfilemanager/raw/main/.github/documentviewer-gnome.png)
+![Show in Windows Explorer](https://github.com/damonlynch/showinfilemanager/raw/main/.github/photomechanic-win.png) ![Open containing folder](https://github.com/damonlynch/showinfilemanager/raw/main/.github/documentviewer-gnome.png)
 
 Commands like these open the file manager, ideally with the files selected:
 
 ![Peony file manager](https://github.com/damonlynch/showinfilemanager/raw/main/.github/peony-kylin.png)
 
-With **Show in File Manager**, your Python program or command line script
-can do the same, with minimum effort from you.
-Although this package provides several functions to assist in identifying
-the system's file managers, in most circumstances you need to call only
-one function, the function `show_in_file_manager`, and it should just work.
+With **Show in File Manager**, your Python program or command line script can do the same, with minimum effort from you. Although this package provides several functions to assist in identifying the system's file managers, in most circumstances you need to call only one function, the function `show_in_file_manager`, and it should just work.
 
-This package aspires to be platform independent, but it currently supports
-only Windows 10/11, Linux,
-[WSL1 and WSL2](https://docs.microsoft.com/en-us/windows/wsl/), and macOS.
-It works with 20 [supported file managers](#supported-file-managers).
+This package aspires to be platform independent, but it currently supports only Windows 10/11, Linux, [WSL1 and WSL2](https://docs.microsoft.com/en-us/windows/wsl/), and macOS. It works with 20 [supported file managers](#supported-file-managers).
 
 ## Install and run
 
@@ -191,8 +177,7 @@ def show_in_file_manager(
     """
 ```
 
-Other functions mentioned below are not necessary to call, but are provided
-for convenience and control.
+Other functions mentioned below are not necessary to call, but are provided for convenience and control.
 
 ### Determine the most sensible choice of file manager
 
@@ -216,15 +201,11 @@ def valid_file_manager() -> str:
     """
 ```
 
-This package makes opinionated choices about the most sensible choice of
-file manager:
+This package makes opinionated choices about the most sensible choice of file manager:
 
-1. A file manager is valid if and only if this package recognizes it, e.g.
-   `nautilus`, `explorer.exe`.
-2. If the user's choice of file manager is valid (i.e. an actual file
-   manager, not some random application), that file manager is used.
-3. If the user's choice of file manager is invalid or could not be
-   determined, the desktop or OS's stock file manager is used.
+1. A file manager is valid if and only if this package recognizes it, e.g. `nautilus`, `explorer.exe`.
+1. If the user's choice of file manager is valid (i.e. an actual file manager, not some random application), that file manager is used.
+1. If the user's choice of file manager is invalid or could not be determined, the desktop or OS's stock file manager is used.
 
 ### Get the operating system's stock file manager
 
@@ -257,17 +238,13 @@ def user_file_manager() -> str:
     """
 ```
 
-On Windows and macOS, for now only the stock file manager is returned. That
-could change in future releases.
+On Windows and macOS, for now only the stock file manager is returned. That could change in future releases.
 
-On Linux, the file manager is probed using `xdg-mime query default 
-inode/directory`, and the resulting `.desktop` file is parsed to extract the
-file manager command.
+On Linux, the file manager is probed using `xdg-mime query default  inode/directory`, and the resulting `.desktop` file is parsed to extract the file manager command.
 
 ## Examples
 
-From Python, show file or directory in file manager, using the most sensible
-choice of file manager:
+From Python, show file or directory in file manager, using the most sensible choice of file manager:
 
 ```python
 # Windows path, in Windows or from within WSL
@@ -297,8 +274,7 @@ show_in_file_manager('/home/user')
 show_in_file_manager('/home/user', open_not_select_directory=False)
 ```
 
-Open the system home directory (`/home` on Linux, `/Users` on macOS) and
-select the user's home folder in it:
+Open the system home directory (`/home` on Linux, `/Users` on macOS) and select the user's home folder in it:
 
 ```bash
 showinfilemanager -s ~
@@ -316,22 +292,17 @@ Select files in two different directories, and open a third directory:
 showinfilemanager myfile.txt ../anotherfile.txt ../../
 ```
 
-The previous command will open three different instances of the file manager,
-because of three different directories (macOS users may need to adjust
-finder preferences in order to display multiple finder windows).
+The previous command will open three different instances of the file manager, because of three different directories (macOS users may need to adjust finder preferences in order to display multiple finder windows).
 
 ## Limitations
 
-- Its behavior in a confined Linux environment like a Flatpak, Snap, or
-  AppImage is untested.
+- Its behavior in a confined Linux environment like a Flatpak, Snap, or AppImage is untested.
 
 ## Contributing
 
-Please file issues or pull requests to improve the code. Discuss
-improvements in the GitHub discussion section for this project.
+Please file issues or pull requests to improve the code. Discuss improvements in the GitHub discussion section for this project.
 
-The initial source of this code is from
-[Rapid Photo Downloader](https://github.com/damonlynch/rapid-photo-downloader).
+The initial source of this code is from [Rapid Photo Downloader](https://github.com/damonlynch/rapid-photo-downloader).
 
 ## License
 

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,14 +1,8 @@
-Release Notes for Show in File Manager 1.1.6
-============================================
+# Release Notes for Show in File Manager 1.1.6
 
-- Show in File Manager 1.1.6 switches its build system from `setuptools` to
-  [Hatch](https://github.com/pypa/hatch).
-    - `hatch build -t sdist` now produces an archive of the project's
-      source code.
-    - `hatch build -t wheel` now produces a wheel (zip archive) of
-      the program's Python code; it also generates the manpage.
+- Show in File Manager 1.1.6 switches its build system from `setuptools` to [Hatch](https://github.com/pypa/hatch).
 
-- To generate the manpage, a new
-  plugin [Hatch-argparse-manpage](https://github.com/damonlynch/hatch-argparse-manpage)
-  is used, which is a new build-time dependency. This plugin can be used
-  with any Hatch project, not just Show in File Manager. 
+  - `hatch build -t sdist` now produces an archive of the project's source code.
+  - `hatch build -t wheel` now produces a wheel (zip archive) of the program's Python code; it also generates the manpage.
+
+- To generate the manpage, a new plugin [Hatch-argparse-manpage](https://github.com/damonlynch/hatch-argparse-manpage) is used, which is a new build-time dependency. This plugin can be used with any Hatch project, not just Show in File Manager.


### PR DESCRIPTION
Remove hard word wrapfrom markdown documents. Reformat using tool
mdformat with formatter mdformat-gfm.