### PR TITLE
dl-branch-2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,23 +2,20 @@
 
 ## 1.1.6 (2026-02-17)
 
-- Support [Cosmic Files](https://github.com/pop-os/cosmic-files)
+- Support [Cosmic Files](https://github.com/pop-os/cosmic-files).
 - Add check for "kde:plasma" in environment variable `XDG_CURRENT_DESKTOP`.
-- Fix [#27](https://github.com/damonlynch/showinfilemanager/issues/27):
-  Incorrect behavior when Windows explorer hides file extensions. Thanks to
-  tpl2go for the fix.
+- Fix [#27](https://github.com/damonlynch/showinfilemanager/issues/27): Incorrect behavior when Windows explorer hides file extensions. Thanks to tpl2go for the fix.
+- Fix [#29](https://github.com/damonlynch/showinfilemanager/issues/29) :Directory names with Unicode do not open correctly in file managers that cannot select files. Thanks to nipatriknilsson for identifying the underlying problem.
 - Drop Python 3.8 and 3.9 support. Use Python 3.10+ typing syntax.
 - Add `__version__` to package.
 - `hatch build -t sdist` now produces an archive of the project's source code.
-- `hatch build -t wheel` now produces a wheel (zip archive) of the program's
-  Python code; it also generates the manpage.
+- `hatch build -t wheel` now produces a wheel (zip archive) of the program's Python code; it also generates the manpage.
 
 ## 1.1.6a1 (2024-04-18)
 
 - Update SPDX headers to be compliant with spec.
 - Switch to [hatch](https://hatch.pypa.io/latest/) from setuptools.
-- New build
-  dependency: [hatch-argparse-manpage](https://github.com/damonlynch/hatch-argparse-manpage).
+- New build dependency: [hatch-argparse-manpage](https://github.com/damonlynch/hatch-argparse-manpage).
 - Add [Release Notes](RELEASE_NOTES.md).
 - Refactor: use absolute imports, not relative.
 - Refactor: flatten code by using a new class. The API is unchanged.
@@ -27,8 +24,7 @@
 
 - Drop setup.py and setup.cfg in favor of pyproject.toml.
 - Purge doc directory.
-- New build
-  dependency: [argparse-manpage](https://github.com/praiskup/argparse-manpage)
+- New build dependency: [argparse-manpage](https://github.com/praiskup/argparse-manpage)
 - Generate man page with argparse-manpage instead of pandoc.
 - Format and lint using ruff. Drop black.
 - Drop Python 3.6 and 3.7 support.
@@ -39,34 +35,23 @@
 
 ## 1.1.3 (2022-02-18)
 
-- Fix [#3](https://github.com/damonlynch/showinfilemanager/issues/3): Missing
-  dependency on packaging.
+- Fix [#3](https://github.com/damonlynch/showinfilemanager/issues/3): Missing dependency on packaging.
 
 ## 1.1.2 (2021-12-27)
 
-- Add check for "unity:unity7:ubuntu" in environment variable
-  XDG_CURRENT_DESKTOP.
-  See https://github.com/damonlynch/rapid-photo-downloader/issues/46.
+- Add check for "unity:unity7:ubuntu" in environment variable XDG_CURRENT_DESKTOP. See https://github.com/damonlynch/rapid-photo-downloader/issues/46.
 
 ## 1.1.1 (2021-10-31)
 
-- Add `allow_conversion` switch to `show_in_file_manager()`. Set to False if
-  passing non-standard URIs.
+- Add `allow_conversion` switch to `show_in_file_manager()`. Set to False if passing non-standard URIs.
 - Recognize non-standard URI prefix 'camera:/', used by KDE.
-- Added function `linux_desktop_humanize()`, to make Linux desktop environment
-  variable name values human friendly.
+- Added function `linux_desktop_humanize()`, to make Linux desktop environment variable name values human friendly.
 
 ## 1.1.0 (2021-10-29)
 
-- On WSL2, use a Linux file manager (if set) for WSL paths, and Windows Explorer
-  for Windows paths. If no Linux file manager is installed, use Windows
-  Explorer. To override the default choice of using Explorer for Windows paths,
-  simply specify a file manager of your choice.
-- On both WSL1 and WSL2, use Windows style URIs to work around
-  a [bug](https://github.com/microsoft/WSL/issues/7603) in WSL where using the
-  /select switch while passing a path with spaces in it fails.
-- Don't mess up the terminal when launching Windows Explorer from WSL on Windows
-  Terminal.
+- On WSL2, use a Linux file manager (if set) for WSL paths, and Windows Explorer for Windows paths. If no Linux file manager is installed, use Windows Explorer. To override the default choice of using Explorer for Windows paths, simply specify a file manager of your choice.
+- On both WSL1 and WSL2, use Windows style URIs to work around a [bug](https://github.com/microsoft/WSL/issues/7603) in WSL where using the /select switch while passing a path with spaces in it fails.
+- Don't mess up the terminal when launching Windows Explorer from WSL on Windows Terminal.
 
 ## 1.0.1 (2021-10-23)
 
@@ -102,8 +87,7 @@
 - Add setup.py for man page generation.
 - Improve README to clarify installation and usage.
 - Parse filename globs passed via the command line on Windows.
-- Use win32 API to execute explorer.exe on Windows, allowing for multiple file
-  selection.
+- Use win32 API to execute explorer.exe on Windows, allowing for multiple file selection.
 
 ## 0.0.4 (2021-08-14)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog for Show in File Manager
 
-## 1.1.6 (2026-02-16)
+## 1.1.6 (2026-02-17)
 
 - Support [Cosmic Files](https://github.com/pop-os/cosmic-files)
 - Add check for "kde:plasma" in environment variable `XDG_CURRENT_DESKTOP`.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -102,8 +102,7 @@
 
 ## 0.0.2 (2021-08-12)
 
-- Move config data from `__about__.py` to static config in
-  `pyproject.toml` [(PEP 621)](https://www.python.org/dev/peps/pep-0621/).
+- Move config data from `__about__.py` to static config in `pyproject.toml` [(PEP 621)](https://www.python.org/dev/peps/pep-0621/).
 - Added command line arguments `--debug` and `--verbose`.
 
 ## 0.0.1 (2021-08-12)

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # Show in File Manager
 
 |         |                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                             |
-| ------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+|---------|---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
 | Package | [![PyPI - Version](https://img.shields.io/pypi/v/show-in-file-manager.svg)](https://pypi.org/project/show-in-file-manager) [![PyPI - Python Version](https://img.shields.io/pypi/pyversions/show-in-file-manager.svg?logo=python&label=Python&logoColor=gold)](https://pypi.org/project/show-in-file-manager/)                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                              |
 | Meta    | [![Hatch project](https://img.shields.io/badge/%F0%9F%A5%9A-Hatch-4051b5.svg)](https://github.com/pypa/hatch) [![Ruff](https://img.shields.io/endpoint?url=https://raw.githubusercontent.com/astral-sh/ruff/main/assets/badge/v2.json)](https://github.com/astral-sh/ruff) [![GitButler](https://img.shields.io/badge/GitButler-%23B9F4F2?logo=data%3Aimage%2Fsvg%2Bxml%3Bbase64%2CPHN2ZyB3aWR0aD0iMzkiIGhlaWdodD0iMjgiIHZpZXdCb3g9IjAgMCAzOSAyOCIgZmlsbD0ibm9uZSIgeG1sbnM9Imh0dHA6Ly93d3cudzMub3JnLzIwMDAvc3ZnIj4KPHBhdGggZD0iTTI1LjIxNDUgMTIuMTk5N0wyLjg3MTA3IDEuMzg5MTJDMS41NDI5NSAwLjc0NjUzMiAwIDEuNzE0MDYgMCAzLjE4OTQ3VjI0LjgxMDVDMCAyNi4yODU5IDEuNTQyOTUgMjcuMjUzNSAyLjg3MTA3IDI2LjYxMDlMMjUuMjE0NSAxNS44MDAzQzI2LjcxOTcgMTUuMDcyMSAyNi43MTk3IDEyLjkyNzkgMjUuMjE0NSAxMi4xOTk3WiIgZmlsbD0iYmxhY2siLz4KPHBhdGggZD0iTTEzLjc4NTUgMTIuMTk5N0wzNi4xMjg5IDEuMzg5MTJDMzcuNDU3MSAwLjc0NjUzMiAzOSAxLjcxNDA2IDM5IDMuMTg5NDdWMjQuODEwNUMzOSAyNi4yODU5IDM3LjQ1NzEgMjcuMjUzNSAzNi4xMjg5IDI2LjYxMDlMMTMuNzg1NSAxNS44MDAzQzEyLjI4MDMgMTUuMDcyMSAxMi4yODAzIDEyLjkyNzkgMTMuNzg1NSAxMi4xOTk3WiIgZmlsbD0idXJsKCNwYWludDBfcmFkaWFsXzMxMF8xMjkpIi8%2BCjxkZWZzPgo8cmFkaWFsR3JhZGllbnQgaWQ9InBhaW50MF9yYWRpYWxfMzEwXzEyOSIgY3g9IjAiIGN5PSIwIiByPSIxIiBncmFkaWVudFVuaXRzPSJ1c2VyU3BhY2VPblVzZSIgZ3JhZGllbnRUcmFuc2Zvcm09InRyYW5zbGF0ZSgxNi41NzAxIDE0KSBzY2FsZSgxOS44NjQxIDE5LjgzODMpIj4KPHN0b3Agb2Zmc2V0PSIwLjMwMTA1NiIgc3RvcC1vcGFjaXR5PSIwIi8%2BCjxzdG9wIG9mZnNldD0iMSIvPgo8L3JhZGlhbEdyYWRpZW50Pgo8L2RlZnM%2BCjwvc3ZnPgo%3D)](https://gitbutler.com/) [![Checked with mypy](http://www.mypy-lang.org/static/mypy_badge.svg)](http://mypy-lang.org/) [![License - MIT](https://img.shields.io/badge/license-MIT-9400d3.svg)](https://spdx.org/licenses/) [![GitHub Sponsors](https://img.shields.io/github/sponsors/damonlynch?logo=GitHub%20Sponsors&style=social)](https://github.com/sponsors/damonlynch) |
 
@@ -57,38 +57,17 @@ This package solves the following problems:
 - How do I supply command line arguments to select files in the file manager?
 - What about file managers with limited features?
 
-There is no standard command line argument with which to open an operating
-system's file manager and select files at a specified path. Moreover, not
-all file managers support specifying files to select &mdash; if you try to
-pass a file to some file managers, they will open the file instead of
-selecting it, or worse yet display an error message. Some file managers will
-only allow selecting one file at a time from the command line.
+There is no standard command line argument with which to open an operating system's file manager and select files at a specified path. Moreover, not all file managers support specifying files to select — if you try to pass a file to some file managers, they will open the file instead of selecting it, or worse yet display an error message. Some file managers will only allow selecting one file at a time from the command line.
 
-On desktop Linux the problem is especially acute, as Linux provides a
-plethora of file managers, with widely varying command line arguments.
-Moreover, the user's default file manager can sometimes be incorrectly set
-to nonsensical values, such as an AppImage or Flatpak of a random application.
+On desktop Linux the problem is especially acute, as Linux provides a plethora of file managers, with widely varying command line arguments. Moreover, the user's default file manager can sometimes be incorrectly set to nonsensical values, such as an AppImage or Flatpak of a random application.
 
-Windows is not without its share of limitations. Windows Explorer will select
-only one file at a time when called from the command line, and the argument
-must be quoted in a way peculiar to it. Rather than using the command line
-to launch Windows Explorer, this package instead uses the
-[Win32 API](https://docs.microsoft.com/en-us/windows/win32/api/shlobj_core/nf-shlobj_core-shopenfolderandselectitems)
-to programmatically select multiple files. Using the Win32 API is not
-possible when calling Windows Explorer from within WSL &mdash; this package
-will launch `explorer.exe` using the command line under WSL. Calling Windows
-Explorer from within WSL is not trivial due to differences in URI and path
-formats between Windows and Linux.
+Windows is not without its share of limitations. Windows Explorer will select only one file at a time when called from the command line, and the argument must be quoted in a way peculiar to it. Rather than using the command line to launch Windows Explorer, this package instead uses the [Win32 API](https://docs.microsoft.com/en-us/windows/win32/api/shlobj_core/nf-shlobj_core-shopenfolderandselectitems) to programmatically select multiple files. Using the Win32 API is not possible when calling Windows Explorer from within WSL — this package will launch `explorer.exe` using the command line under WSL. Calling Windows Explorer from within WSL is not trivial due to differences in URI and path formats between Windows and Linux.
 
 ## Supported file managers
 
-This package takes care of calling the file managers with the correct
-arguments for you. The command line arguments shown here are for reference.
+This package takes care of calling the file managers with the correct arguments for you. The command line arguments shown here are for reference.
 
-All but two file managers
-accept [URIs](https://en.wikipedia.org/wiki/Uniform_Resource_Identifier)
-like `file:///home/user/file.txt` in addition to regular paths like
-`/home/user/file.txt`.
+All but two file managers accept [URIs](https://en.wikipedia.org/wiki/Uniform_Resource_Identifier) like `file:///home/user/file.txt` in addition to regular paths like `/home/user/file.txt`.
 
 | File Manager                                                                                    | Used by                                            | Command line                             | Can Select Files | Handles Multiple Files / Directories | Notes                                                                                                                                                                                                                                                    |
 |-------------------------------------------------------------------------------------------------|----------------------------------------------------|------------------------------------------|:----------------:|:------------------------------------:|----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
@@ -119,11 +98,12 @@ like `file:///home/user/file.txt` in addition to regular paths like
 
 ```python
 def show_in_file_manager(
-        path_or_uri: Optional[Union[str, Sequence[str]]] = None,
-        open_not_select_directory: Optional[bool] = True,
-        file_manager: Optional[str] = None,
-        verbose: bool = False,
-        debug: bool = False,
+    path_or_uri: str | Sequence[str] | None = None,
+    open_not_select_directory: bool = True,
+    file_manager: str | None = None,
+    allow_conversion: bool = True,
+    verbose: bool = False,
+    debug: bool = False,
 ) -> None:
     """
     Open the file manager and show zero or more directories or files in it.
@@ -204,8 +184,8 @@ def valid_file_manager() -> str:
 This package makes opinionated choices about the most sensible choice of file manager:
 
 1. A file manager is valid if and only if this package recognizes it, e.g. `nautilus`, `explorer.exe`.
-1. If the user's choice of file manager is valid (i.e. an actual file manager, not some random application), that file manager is used.
-1. If the user's choice of file manager is invalid or could not be determined, the desktop or OS's stock file manager is used.
+2. If the user's choice of file manager is valid (i.e. an actual file manager, not some random application), that file manager is used.
+3. If the user's choice of file manager is invalid or could not be determined, the desktop or OS's stock file manager is used.
 
 ### Get the operating system's stock file manager
 

--- a/src/showinfm/filemanager.py
+++ b/src/showinfm/filemanager.py
@@ -296,16 +296,23 @@ class FileManager:
             # there is no need to use tools.file_url_to_path() to handle the
             # file:/// case that urllib.parse.urlparse fails with.
             parse_result = urllib.parse.urlparse(uri)
-            path = Path(parse_result.path)
+            quoted_path = parse_result.path
+            # unquote the path before checking for its existence (below)
+            path = Path(urllib.parse.unquote(parse_result.path))
         else:
             parse_result = None
+            quoted_path = None
 
         assert path is not None
 
         if not (path.is_dir() and self.open_not_select_directory):
             path = path.parent
+
         if uri:
             assert parse_result is not None
+            # Use the original quoted path
+            assert quoted_path is not None
+            path = Path(quoted_path)
             uri = str(urllib.parse.urlunparse(parse_result._replace(path=str(path))))
         else:
             path = tools.quote_path(path=path)


### PR DESCRIPTION
Summary
- Preserve quoted path when rewriting file:// URIs to avoid dropping percent-encoding.
- Use unquoted path only for filesystem checks; use original quoted path when reconstructing URIs.
- Add assertions and comments to prevent accidental use of unquoted paths in URI reconstruction.
- Fixes incorrect URI rewriting for paths containing characters that require percent-encoding (fixes #29).
- Update CHANGELOG.md date for 1.1.6 release.
- Reapply mdformat-based documentation formatting and manual cleanups (two identical reformat commits).

Related issues, if any
- Fixes #29

Notes
- Formatting changes are reapplications after an incorrect PyCharm config.