### PR TITLE
fix(filemanager): restore parent path functionality

### DIFF
--- a/src/showinfm/filemanager.py
+++ b/src/showinfm/filemanager.py
@@ -296,12 +296,9 @@ class FileManager:
             # there is no need to use tools.file_url_to_path() to handle the
             # file:/// case that urllib.parse.urlparse fails with.
             parse_result = urllib.parse.urlparse(uri)
-            quoted_path = parse_result.path
-            # unquote the path before checking for its existence (below)
             path = Path(urllib.parse.unquote(parse_result.path))
         else:
             parse_result = None
-            quoted_path = None
 
         assert path is not None
 
@@ -309,10 +306,7 @@ class FileManager:
             path = path.parent
 
         if uri:
-            assert parse_result is not None
-            # Use the original quoted path
-            assert quoted_path is not None
-            path = Path(quoted_path)
+            path = urllib.parse.quote(str(path))
             uri = str(urllib.parse.urlunparse(parse_result._replace(path=str(path))))
         else:
             path = tools.quote_path(path=path)


### PR DESCRIPTION
When unquoting the path component of a URI, and modifying it to find its
parent, quote the modified path, not the original. This restores the
original logic before the previous unquote / quote fix.